### PR TITLE
Fix for error when training chunk is selected from the end of the file.

### DIFF
--- a/train.py
+++ b/train.py
@@ -36,7 +36,7 @@ def random_training_set(chunk_len, batch_size):
     inp = torch.LongTensor(batch_size, chunk_len)
     target = torch.LongTensor(batch_size, chunk_len)
     for bi in range(batch_size):
-        start_index = random.randint(0, file_len - chunk_len)
+        start_index = random.randint(0, file_len - chunk_len - 1)
         end_index = start_index + chunk_len + 1
         chunk = file[start_index:end_index]
         inp[bi] = char_tensor(chunk[:-1])


### PR DESCRIPTION
When the random training chunk selection coincides with the end of the input file, the training tensor happens to have 1 missing character and tensor size mismatch error is thrown.

In random_training_set() method:
```
for bi in range(batch_size):
        start_index = random.randint(0, file_len - chunk_len)
        end_index = start_index + chunk_len + 1
        chunk = file[start_index:end_index]
```
since `random.randint()` method's upper limit is inclusive, we need to substract 1 from the second argument.