### PR TITLE
Fix off-by-one error in train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -37,7 +37,7 @@ def random_training_set(chunk_len, batch_size):
     inp = torch.LongTensor(batch_size, chunk_len)
     target = torch.LongTensor(batch_size, chunk_len)
     for bi in range(batch_size):
-        start_index = random.randint(0, file_len - chunk_len)
+        start_index = random.randint(0, file_len - chunk_len - 1)
         end_index = start_index + chunk_len + 1
         chunk = file[start_index:end_index]
         inp[bi] = char_tensor(chunk[:-1])


### PR DESCRIPTION
random.randint specifies an inclusive range, so start_index was sometimes (file_len - chunk_len). This would produce input and target tensors of size (chunk_len - 1), instead of chunk_len, making the batch unparallelizable and causing a crash.