### PR TITLE
Map target when loading the model.

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
     argparser.add_argument('--cuda', action='store_true')
     args = argparser.parse_args()
 
-    decoder = torch.load(args.filename)
+    decoder = torch.load(args.filename, map_location = 'cuda' if args.cuda else 'cpu')
     del args.filename
     print(generate(decoder, **vars(args)))
 


### PR DESCRIPTION
Allow to generate samples on a different target (trained on gpu, generate on cpu and vice versa).

Tested with (with corresponding model input.pt):
 python generate.py input.pt --prime_str "JULIA" --predict_len 1000
 python generate.py input.pt --cuda --prime_str "JULIA" --predict_len 1000